### PR TITLE
Task/tg 42 autocomplete warnings

### DIFF
--- a/autocomplete/__init__.py
+++ b/autocomplete/__init__.py
@@ -28,6 +28,6 @@ if 'DJANGO_SETTINGS_MODULE' in os.environ:
 
         set_searchable_fields(model, fields)
 
-__version__ = (2, 0, 1)
+__version__ = (2, 0, 2)
 def get_version():
     return '.'.join(map(str, __version__))

--- a/autocomplete/urls.py
+++ b/autocomplete/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import patterns, url
+from autocomplete.views import search
 
-urlpatterns = patterns(
-    'autocomplete.views',
-    url(r'^$', 'search', name='autocomplete_search'),
-)
+urlpatterns = [
+    url(r'^$', search, name='autocomplete_search'),
+]


### PR DESCRIPTION
This addresses deprecation warning for using strings in url. With version bump. 