### PR TITLE
Omni 1.11

### DIFF
--- a/autocomplete/__init__.py
+++ b/autocomplete/__init__.py
@@ -28,6 +28,6 @@ if 'DJANGO_SETTINGS_MODULE' in os.environ:
 
         set_searchable_fields(model, fields)
 
-__version__ = (2, 0, 2)
+__version__ = (2, 1, 0, 'dev')
 def get_version():
     return '.'.join(map(str, __version__))

--- a/autocomplete/widgets.py
+++ b/autocomplete/widgets.py
@@ -2,7 +2,7 @@ from django.core.urlresolvers import reverse
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import get_model
+from django.apps import apps
 from django.utils.safestring import mark_safe
 from django import forms
 
@@ -84,7 +84,7 @@ class AutocompleteTag(forms.TextInput):
 
         if model is None:
             if hasattr(settings, 'AUTOCOMPLETE_TAG_MODEL'):
-                model = get_model(*settings.AUTOCOMPLETE_TAG_MODEL.split('.', 2))
+                model = apps.get_model(*settings.AUTOCOMPLETE_TAG_MODEL.split('.', 2))
             else:
                 raise ImproperlyConfigured("AUTOCOMPLETE_TAG_MODEL setting not set. Set it to the name of the tag model to autocomplete.")
 


### PR DESCRIPTION
Use `apps.get_model` rather than `db.models.get_model` for django 1.9 compatibility