### PR TITLE
Removed deprecated (and unused) django.conf.urls.patterns

### DIFF
--- a/autocomplete/urls.py
+++ b/autocomplete/urls.py
@@ -1,5 +1,7 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
+
 from autocomplete.views import search
+
 
 urlpatterns = [
     url(r'^$', search, name='autocomplete_search'),


### PR DESCRIPTION
Adds Django `1.10` compatibility.