### PR TITLE
Make python 3 compatible

### DIFF
--- a/autocomplete/__init__.py
+++ b/autocomplete/__init__.py
@@ -28,6 +28,6 @@ if 'DJANGO_SETTINGS_MODULE' in os.environ:
 
         set_searchable_fields(model, fields)
 
-__version__ = (2, 0, 3)
+__version__ = (2, 0, 4)
 def get_version():
     return '.'.join(map(str, __version__))

--- a/autocomplete/views.py
+++ b/autocomplete/views.py
@@ -1,3 +1,4 @@
+import functools
 import json
 import operator
 
@@ -94,7 +95,7 @@ def search(request):
                           for field_name in search_fields]
             other_qs = QuerySet(model)
             other_qs.query.select_related = qs.query.select_related
-            other_qs = other_qs.filter(reduce(operator.or_, or_queries))
+            other_qs = other_qs.filter(functools.reduce(operator.or_, or_queries))
             qs = qs & other_qs
 
         data = [{'label': o.__unicode__(), 'value': o.pk} for o in qs]

--- a/autocomplete/views.py
+++ b/autocomplete/views.py
@@ -98,7 +98,7 @@ def search(request):
             other_qs = other_qs.filter(functools.reduce(operator.or_, or_queries))
             qs = qs & other_qs
 
-        data = [{'label': o.__unicode__(), 'value': o.pk} for o in qs]
+        data = [{'label': o.__str__(), 'value': o.pk} for o in qs]
 
         return HttpResponse(json.dumps(data), content_type='application/javascript')
 

--- a/autocomplete/widgets.py
+++ b/autocomplete/widgets.py
@@ -2,11 +2,15 @@ from django.core.urlresolvers import reverse
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import get_model
+from django.apps import apps
 from django.utils.safestring import mark_safe
 from django import forms
 
 from autocomplete import add_searchable_fields, AUTOCOMPLETE_URL_NAME
+
+
+get_model = apps.get_model
+
 
 class AutocompleteSelectMultiple(forms.SelectMultiple):
     """
@@ -40,7 +44,7 @@ class AutocompleteSelectMultiple(forms.SelectMultiple):
         super(AutocompleteSelectMultiple, self).__init__(attrs)
 
     def render(self, name, value, attrs=None):
-        self.choices = value and [(o.pk, unicode(o)) for o in self.model.objects.filter(pk__in=value)] or []
+        self.choices = value and [(o.pk, str(o)) for o in self.model.objects.filter(pk__in=value)] or []
 
         rendered = super(AutocompleteSelectMultiple, self).render(name,value, attrs)
 


### PR DESCRIPTION
# Make `python3` compatible

This PR makes this compatible with python3 by replacing `unicode` methods with `str` methods and re-pointing the source of `get_model` and `reduce`.